### PR TITLE
Fix sales data

### DIFF
--- a/scripts/update-sale-currency-conversions.ts
+++ b/scripts/update-sale-currency-conversions.ts
@@ -21,7 +21,10 @@ const main = async () => {
     synchronize: true,
     logging: false,
   }).then(async (connection) => {
-    const sales = await Sale.createQueryBuilder("sale").getMany();
+    const sales = await Sale.createQueryBuilder("sale")
+      .where("sale.price != 0")
+      .andWhere("sale.priceBase = 0")
+      .getMany();
     const tokenAddressPrices = await fetchTokenAddressPrices();
 
     await updateSaleCurrencyConversions(sales, tokenAddressPrices);

--- a/scripts/update-sale-currency-conversions.ts
+++ b/scripts/update-sale-currency-conversions.ts
@@ -1,0 +1,31 @@
+import { createConnection } from "typeorm";
+import { Sale } from "../src/models/sale";
+import { Collection } from "../src/models/collection";
+import { Statistic } from "../src/models/statistic";
+import { HistoricalStatistic } from "../src/models/historical-statistic";
+import { DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER } from "../env";
+import {
+  fetchTokenAddressPrices,
+  updateSaleCurrencyConversions,
+} from "../src/adapters/currency-converter-adapter";
+
+const main = async () => {
+  createConnection({
+    type: "postgres",
+    host: DB_HOST,
+    port: DB_PORT,
+    username: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_NAME,
+    entities: [Sale, Collection, Statistic, HistoricalStatistic],
+    synchronize: true,
+    logging: false,
+  }).then(async (connection) => {
+    const sales = await Sale.createQueryBuilder("sale").getMany();
+    const tokenAddressPrices = await fetchTokenAddressPrices();
+
+    await updateSaleCurrencyConversions(sales, tokenAddressPrices);
+  });
+};
+
+main();

--- a/src/adapters/currency-converter-adapter.ts
+++ b/src/adapters/currency-converter-adapter.ts
@@ -24,15 +24,13 @@ async function runSaleCurrencyConversions(): Promise<void> {
   const sales = await Sale.getUnconvertedSales();
   const tokenAddressPrices = await fetchTokenAddressPrices();
 
-  console.log("Updating currency conversions for", sales.length, "sales");
-
   await updateSaleCurrencyConversions(sales, tokenAddressPrices);
 }
 
-async function fetchTokenAddressPrices(): Promise<Record<string, number[][]>> {
+export async function fetchTokenAddressPrices(): Promise<Record<string, number[][]>> {
   const tokenAddressPrices: Record<string, number[][]> = {};
 
-  const tokenAddressesRaw = await Sale.getUnconvertedSalesTokenAddresses();
+  const tokenAddressesRaw = await Sale.getPaymentTokenAddresses(false);
   const tokenAddresses = tokenAddressesRaw
     .map((data) => data.tokenAddress)
     .filter((data) => !BASE_TOKENS_ADDRESSES.includes(data));
@@ -69,10 +67,12 @@ async function fetchTokenAddressPrices(): Promise<Record<string, number[][]>> {
 }
 
 //TODO optimize and refactor
-async function updateSaleCurrencyConversions(
+export async function updateSaleCurrencyConversions(
   sales: Sale[],
   tokenAddressPrices: Record<string, number[][]>
 ): Promise<void> {
+  console.log("Updating currency conversions for", sales.length, "sales");
+
   for (const sale of sales) {
     const saleTokenAddress = sale.paymentTokenAddress;
     const saleTimestamp = sale.timestamp.toString();

--- a/src/adapters/currency-converter-adapter.ts
+++ b/src/adapters/currency-converter-adapter.ts
@@ -81,7 +81,7 @@ async function updateSaleCurrencyConversions(): Promise<void> {
     ) {
       count++;
       const timestamp = sale.timestamp.toString();
-      const priceBase = getPriceAtDate(
+      const priceBase = sale.price * getPriceAtDate(
         timestamp,
         tokenAddressPrices[sale.paymentTokenAddress]
       );

--- a/src/adapters/currency-converter-adapter.ts
+++ b/src/adapters/currency-converter-adapter.ts
@@ -72,6 +72,8 @@ async function updateSaleCurrencyConversions(): Promise<void> {
   let count = 0;
   for (const sale of sales) {
     // TODO generalize for other chains
+    console.log(sale.paymentTokenAddress, "is found in price data:", sale.paymentTokenAddress in tokenAddressPrices)
+
     if (
       sale.paymentTokenAddress in tokenAddressPrices &&
       sale.paymentTokenAddress != ETHEREUM_DEFAULT_TOKEN_ADDRESS &&
@@ -90,8 +92,9 @@ async function updateSaleCurrencyConversions(): Promise<void> {
             tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS]
           )
       );
-      sale.priceBase = priceBase ?? 0;
-      sale.priceUSD = priceUSD ?? BigInt(0);
+
+      sale.priceBase = priceBase ?? -1;
+      sale.priceUSD = priceUSD ?? BigInt(-1);
       console.log(
         sale.txnHash,
         "successfully updated. no",
@@ -136,6 +139,8 @@ async function updateSaleCurrencyConversions(): Promise<void> {
     } else {
       //TODO handle for token addresses whose prices cant be found
       console.log("price data not found for txn hash", sale.txnHash);
+      sale.priceBase = -1;
+      sale.priceUSD = BigInt(-1);
     }
   }
 

--- a/src/adapters/currency-converter-adapter.ts
+++ b/src/adapters/currency-converter-adapter.ts
@@ -1,0 +1,147 @@
+import axios from "axios";
+import { Sale } from "../models/sale";
+import { DataAdapter } from ".";
+import { Coingecko } from "../api/coingecko";
+import { getPriceAtDate, sleep, formatUSD } from "../utils";
+import {
+  ETHEREUM_DEFAULT_TOKEN_ADDRESS,
+  SOLANA_DEFAULT_TOKEN_ADDRESS,
+} from "../constants";
+
+const DEFAULT_TOKENS = [
+  ETHEREUM_DEFAULT_TOKEN_ADDRESS,
+  SOLANA_DEFAULT_TOKEN_ADDRESS,
+];
+
+async function run(): Promise<void> {
+  while (true) {
+    console.log("Running currency converter");
+    await updateSaleCurrencyConversions();
+    await sleep(60 * 60);
+  }
+}
+
+//TODO optimize
+async function updateSaleCurrencyConversions(): Promise<void> {
+  const sales = await Sale.getUnconverted();
+
+  const tokenAddresses = sales.reduce((addresses, sale) => {
+    const tokenAddress = sale.paymentTokenAddress;
+    const notBaseToken = !DEFAULT_TOKENS.includes(tokenAddress);
+    const isUnique = !addresses.includes(tokenAddress);
+    if (notBaseToken && isUnique) {
+      addresses.push(tokenAddress);
+    }
+    return addresses;
+  }, []);
+
+  let tokenAddressPrices: Record<string, number[][]> = {};
+
+  // TODO do not hardcode
+  tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS] =
+    await Coingecko.getHistoricalEthPrices();
+  tokenAddressPrices[SOLANA_DEFAULT_TOKEN_ADDRESS] =
+    await Coingecko.getHistoricalSolPrices();
+
+  for (const tokenAddress of tokenAddresses) {
+    try {
+      //TODO generalize for other chains
+      const prices = await Coingecko.getHistoricalPricesByAddress(
+        "ethereum",
+        tokenAddress,
+        "eth"
+      );
+      tokenAddressPrices[tokenAddress] = prices;
+    } catch (e) {
+      if (axios.isAxiosError(e)) {
+        if (e.response.status === 404) {
+          console.error("Historical prices not found:", e.message);
+        }
+        if (e.response.status === 429) {
+          // Backoff for 1 minute if rate limited
+          await sleep(60);
+        }
+      }
+      console.error("Error retrieving historical prices:", e.message);
+    }
+    await sleep(1);
+  }
+
+  console.log("Updating currency conversions for", sales.length, "sales");
+
+  let count = 0;
+  for (const sale of sales) {
+    // TODO generalize for other chains
+    if (
+      sale.paymentTokenAddress in tokenAddressPrices &&
+      sale.paymentTokenAddress != ETHEREUM_DEFAULT_TOKEN_ADDRESS &&
+      sale.paymentTokenAddress != SOLANA_DEFAULT_TOKEN_ADDRESS
+    ) {
+      count++;
+      const timestamp = sale.timestamp.toString();
+      const priceBase = getPriceAtDate(
+        timestamp,
+        tokenAddressPrices[sale.paymentTokenAddress]
+      );
+      const priceUSD = formatUSD(
+        priceBase *
+          getPriceAtDate(
+            timestamp,
+            tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS]
+          )
+      );
+      sale.priceBase = priceBase ?? 0;
+      sale.priceUSD = priceUSD ?? BigInt(0);
+      console.log(
+        sale.txnHash,
+        "successfully updated. no",
+        count,
+        "of",
+        sales.length
+      );
+    } else if (sale.paymentTokenAddress == ETHEREUM_DEFAULT_TOKEN_ADDRESS) {
+      count++;
+      sale.priceBase = sale.price;
+      sale.priceUSD = formatUSD(
+        sale.price *
+          getPriceAtDate(
+            sale.timestamp.toString(),
+            tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS]
+          )
+      );
+      console.log(
+        sale.txnHash,
+        "successfully updated. no",
+        count,
+        "of",
+        sales.length
+      );
+    } else if (sale.paymentTokenAddress == SOLANA_DEFAULT_TOKEN_ADDRESS) {
+      count++;
+      sale.priceBase = sale.price;
+      sale.priceUSD = formatUSD(
+        sale.price *
+          getPriceAtDate(
+            sale.timestamp.toString(),
+            tokenAddressPrices[SOLANA_DEFAULT_TOKEN_ADDRESS]
+          )
+      );
+      console.log(
+        sale.txnHash,
+        "successfully updated. no",
+        count,
+        "of",
+        sales.length
+      );
+    } else {
+      //TODO handle for token addresses whose prices cant be found
+      console.log("price data not found for txn hash", sale.txnHash);
+    }
+  }
+
+  Sale.save(sales, { chunk: 100 });
+  console.log("saving updated values for", sales.length, "sales");
+}
+
+const CurrencyConverterAdapter: DataAdapter = { run };
+export default CurrencyConverterAdapter;

--- a/src/adapters/currency-converter-adapter.ts
+++ b/src/adapters/currency-converter-adapter.ts
@@ -21,7 +21,7 @@ async function run(): Promise<void> {
   }
 }
 
-//TODO optimize
+//TODO optimize and refactor
 async function updateSaleCurrencyConversions(): Promise<void> {
   const sales = await Sale.getUnconverted();
 
@@ -72,7 +72,11 @@ async function updateSaleCurrencyConversions(): Promise<void> {
   let count = 0;
   for (const sale of sales) {
     // TODO generalize for other chains
-    console.log(sale.paymentTokenAddress, "is found in price data:", sale.paymentTokenAddress in tokenAddressPrices)
+    console.log(
+      sale.paymentTokenAddress,
+      "is found in price data:",
+      sale.paymentTokenAddress in tokenAddressPrices
+    );
 
     if (
       sale.paymentTokenAddress in tokenAddressPrices &&
@@ -81,17 +85,20 @@ async function updateSaleCurrencyConversions(): Promise<void> {
     ) {
       count++;
       const timestamp = sale.timestamp.toString();
-      const priceBase = sale.price * getPriceAtDate(
+      const baseAtDate = getPriceAtDate(
         timestamp,
         tokenAddressPrices[sale.paymentTokenAddress]
       );
-      const priceUSD = formatUSD(
-        priceBase *
-          getPriceAtDate(
-            timestamp,
-            tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS]
+      const priceBase = baseAtDate ? sale.price * baseAtDate : null;
+      const priceUSD = priceBase
+        ? formatUSD(
+            priceBase *
+              getPriceAtDate(
+                timestamp,
+                tokenAddressPrices[ETHEREUM_DEFAULT_TOKEN_ADDRESS]
+              )
           )
-      );
+        : null;
 
       sale.priceBase = priceBase ?? -1;
       sale.priceUSD = priceUSD ?? BigInt(-1);

--- a/src/adapters/historical-statistic-calculator-adapter.ts
+++ b/src/adapters/historical-statistic-calculator-adapter.ts
@@ -1,12 +1,6 @@
 import { Collection } from "../models/collection";
-import { HistoricalStatistic } from "../models/historical-statistic";
 import { DataAdapter } from ".";
-import { Coingecko } from "../api/coingecko";
-import { isSameDay, sleep, roundUSD } from "../utils";
-import {
-  ETHEREUM_DEFAULT_TOKEN_ADDRESS,
-  SOLANA_DEFAULT_TOKEN_ADDRESS,
-} from "../constants";
+import { sleep } from "../utils";
 
 const QUERY = `
 insert into historical_statistic (
@@ -14,8 +8,14 @@ insert into historical_statistic (
   "collectionAddress",
   "dailyVolume",
   floor,
-  "marketCap", "dailyVolumeUSD", "marketCapUSD", "floorUSD", "totalVolume", "totalVolumeUSD", "owners",
-  "tokenAddress"
+  "marketCap",
+  "dailyVolumeBase",
+  "dailyVolumeUSD",
+  "marketCapUSD",
+  "floorUSD",
+  "totalVolume",
+  "totalVolumeUSD",
+  "owners"
 )
 (
   select
@@ -26,68 +26,33 @@ insert into historical_statistic (
     sum(price) as dailyVolume,
     percentile_cont(0.20) within group (order by price) as floor,
     0,
+    sum("priceBase") as dailyVolumeBase,
     sum("priceUSD") as dailyVolumeUSD,
     0,
     0,
     0,
     0,
-    0,
-    "paymentTokenAddress"
+    0
   from sale
   join collection on sale."collectionAddress" = collection.address
   where price != 0
-  and "paymentTokenAddress" = '0x0000000000000000000000000000000000000000'
-  or "paymentTokenAddress" = '11111111111111111111111111111111'
-  group by "collectionAddress", day, "paymentTokenAddress"
+  group by "collectionAddress", day
 )
 on conflict("collectionAddress", timestamp)
 do update set
   "dailyVolume" = excluded."dailyVolume",
+  "dailyVolumeBase" = excluded."dailyVolumeBase",
+  "dailyVolumeUSD" = excluded."dailyVolumeUSD",
   floor = excluded.floor
 ;
 `;
+
 async function run(): Promise<void> {
   while (true) {
     console.log("Running historical statistic calculator");
-    await updateHistoricalStatistics();
     await Collection.query(QUERY);
     await sleep(60 * 60);
   }
-}
-
-async function updateHistoricalStatistics(): Promise<void> {
-  const ethInUSDPrices = await Coingecko.getHistoricalEthPrices();
-  const solInUSDPrices = await Coingecko.getHistoricalSolPrices();
-  const historicalStatistics =
-    await HistoricalStatistic.getIncompleteHistoricalStatistics();
-
-  console.log("Updating", historicalStatistics.length, "incomplete stats");
-
-  historicalStatistics.forEach(async (s) => {
-    if (s.tokenAddress === ETHEREUM_DEFAULT_TOKEN_ADDRESS) {
-      const match = ethInUSDPrices.find((e) => {
-        const d1 = new Date(e[0]);
-        const d2 = new Date(s.timestamp);
-        return isSameDay(d1, d2);
-      });
-
-      if (match) {
-        s.dailyVolumeUSD = BigInt(Math.ceil(s.dailyVolume * match[1])); // Round up so <$1 values aren't continually marked as incomplete
-        s.save();
-      }
-    } else if (s.tokenAddress === SOLANA_DEFAULT_TOKEN_ADDRESS) {
-      const match = solInUSDPrices.find((e) => {
-        const d1 = new Date(e[0]);
-        const d2 = new Date(s.timestamp);
-        return isSameDay(d1, d2);
-      });
-
-      if (match) {
-        s.dailyVolumeUSD = BigInt(Math.ceil(s.dailyVolume * match[1]));
-        s.save();
-      }
-    }
-  });
 }
 
 // LOL at name

--- a/src/adapters/historical-statistic-calculator-adapter.ts
+++ b/src/adapters/historical-statistic-calculator-adapter.ts
@@ -48,10 +48,14 @@ do update set
 `;
 
 async function run(): Promise<void> {
-  while (true) {
-    console.log("Running historical statistic calculator");
-    await Collection.query(QUERY);
-    await sleep(60 * 60);
+  try {
+    while (true) {
+      console.log("Running historical statistic calculator");
+      await Collection.query(QUERY);
+      await sleep(60 * 60);
+    }
+  } catch (e) {
+    console.error("Historical statistic calculator adapter error:", e.message);
   }
 }
 

--- a/src/adapters/immutablex-adapter.ts
+++ b/src/adapters/immutablex-adapter.ts
@@ -46,7 +46,6 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const ethInUSDPrices = await Coingecko.getHistoricalEthPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -58,7 +57,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for IMX collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching sales for IMX collection:", collection.name);
-    await fetchSales(collection, ethInUSDPrices);
+    await fetchSales(collection);
   }
 }
 
@@ -111,7 +110,6 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  ethInUSDPrices: number[][]
 ): Promise<void> {
   const mostRecentSaleTime =
     (
@@ -121,7 +119,6 @@ async function fetchSales(
     const salesEvents = await ImmutableX.getSales(
       collection,
       mostRecentSaleTime,
-      ethInUSDPrices
     );
 
     if (salesEvents.length === 0) {

--- a/src/adapters/immutablex-adapter.ts
+++ b/src/adapters/immutablex-adapter.ts
@@ -46,7 +46,7 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const ethInUSD = await Coingecko.getEthPrice();
+  const ethInUSDPrices = await Coingecko.getHistoricalEthPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -58,7 +58,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for IMX collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching sales for IMX collection:", collection.name);
-    await fetchSales(collection, ethInUSD);
+    await fetchSales(collection, ethInUSDPrices);
   }
 }
 
@@ -111,7 +111,7 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  ethInUSD: number
+  ethInUSDPrices: number[][]
 ): Promise<void> {
   const mostRecentSaleTime =
     (
@@ -121,7 +121,7 @@ async function fetchSales(
     const salesEvents = await ImmutableX.getSales(
       collection,
       mostRecentSaleTime,
-      ethInUSD
+      ethInUSDPrices
     );
 
     if (salesEvents.length === 0) {

--- a/src/adapters/immutablex-adapter.ts
+++ b/src/adapters/immutablex-adapter.ts
@@ -10,13 +10,6 @@ import { Coingecko } from "../api/coingecko";
 import { sleep, getSlug } from "../utils";
 import { ONE_HOUR } from "../constants";
 
-async function run(): Promise<void> {
-  while (true) {
-    await Promise.all([runCollections(), runSales()]);
-    await sleep(60 * 60);
-  }
-}
-
 async function runCollections(): Promise<void> {
   const collections = await ImmutableX.getAllCollections();
 
@@ -108,9 +101,7 @@ async function fetchCollection(
   storedCollection.save();
 }
 
-async function fetchSales(
-  collection: Collection,
-): Promise<void> {
+async function fetchSales(collection: Collection): Promise<void> {
   const mostRecentSaleTime =
     (
       await collection.getLastSale(Marketplace.ImmutableX)
@@ -118,7 +109,7 @@ async function fetchSales(
   try {
     const salesEvents = await ImmutableX.getSales(
       collection,
-      mostRecentSaleTime,
+      mostRecentSaleTime
     );
 
     if (salesEvents.length === 0) {
@@ -159,6 +150,17 @@ async function fetchSales(
         await sleep(60);
       }
     }
+  }
+}
+
+async function run(): Promise<void> {
+  try {
+    while (true) {
+      await Promise.all([runCollections(), runSales()]);
+      await sleep(60 * 60);
+    }
+  } catch (e) {
+    console.error("ImmutableX adapter error:", e.message);
   }
 }
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,11 +10,11 @@ export interface DataAdapter {
 }
 
 const adapters: DataAdapter[] = [
-  //MoralisAdapter,
-  //OpenseaAdapter,
-  //MagicEdenAdapter,
-  //ImmutableXAdapter,
-  //HistoricalStatisticCalculatorAdapter,
+  MoralisAdapter,
+  OpenseaAdapter,
+  MagicEdenAdapter,
+  ImmutableXAdapter,
+  HistoricalStatisticCalculatorAdapter,
   CurrencyConverterAdapter,
 ];
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,8 +1,9 @@
-import HistoricalStatisticCalculatorAdapter from "./historical-statistic-calculator-adapter";
 import MoralisAdapter from "./moralis-adapter";
 import OpenseaAdapter from "./opensea-adapter";
 import MagicEdenAdapter from "./magic-eden-adapter";
 import ImmutableXAdapter from "./immutablex-adapter";
+import HistoricalStatisticCalculatorAdapter from "./historical-statistic-calculator-adapter";
+import CurrencyConverterAdapter from "./currency-converter-adapter";
 
 export interface DataAdapter {
   run: () => Promise<void>;
@@ -14,6 +15,7 @@ const adapters: DataAdapter[] = [
   MagicEdenAdapter,
   ImmutableXAdapter,
   HistoricalStatisticCalculatorAdapter,
+  CurrencyConverterAdapter,
 ];
 
 export { adapters };

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,11 +10,11 @@ export interface DataAdapter {
 }
 
 const adapters: DataAdapter[] = [
-  MoralisAdapter,
-  OpenseaAdapter,
-  MagicEdenAdapter,
-  ImmutableXAdapter,
-  HistoricalStatisticCalculatorAdapter,
+  //MoralisAdapter,
+  //OpenseaAdapter,
+  //MagicEdenAdapter,
+  //ImmutableXAdapter,
+  //HistoricalStatisticCalculatorAdapter,
   CurrencyConverterAdapter,
 ];
 

--- a/src/adapters/magic-eden-adapter.ts
+++ b/src/adapters/magic-eden-adapter.ts
@@ -45,7 +45,6 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const solInUSDPrices = await Coingecko.getHistoricalSolPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -57,7 +56,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for Magic Eden collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching Sales for Magic Eden collection:", collection.name);
-    await fetchSales(collection, solInUSDPrices);
+    await fetchSales(collection);
   }
 }
 
@@ -115,7 +114,6 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  solInUSDPrices: number[][]
 ): Promise<void> {
   const mostRecentSaleTime =
     (
@@ -125,7 +123,6 @@ async function fetchSales(
     const salesEvents = await MagicEden.getSales(
       collection,
       mostRecentSaleTime,
-      solInUSDPrices
     );
 
     if (salesEvents.length === 0) {

--- a/src/adapters/magic-eden-adapter.ts
+++ b/src/adapters/magic-eden-adapter.ts
@@ -9,13 +9,6 @@ import { Coingecko } from "../api/coingecko";
 import { sleep } from "../utils";
 import { ONE_HOUR } from "../constants";
 
-async function run(): Promise<void> {
-  while (true) {
-    await Promise.all([runCollections(), runSales()]);
-    await sleep(60 * 60);
-  }
-}
-
 async function runCollections(): Promise<void> {
   const collections = await MagicEden.getAllCollections();
 
@@ -55,7 +48,7 @@ async function runSales(): Promise<void> {
 
   console.log("Fetching sales for Magic Eden collections:", collections.length);
   for (const collection of collections) {
-    console.log("Fetching Sales for Magic Eden collection:", collection.name);
+    console.log("Fetching sales for Magic Eden collection:", collection.name);
     await fetchSales(collection);
   }
 }
@@ -106,15 +99,13 @@ async function fetchCollection(
     } else {
       storedCollection.statistic = Statistic.create({ ...statistics });
     }
-    
+
     storedCollection.lastFetched = new Date(Date.now());
     storedCollection.save();
   }
 }
 
-async function fetchSales(
-  collection: Collection,
-): Promise<void> {
+async function fetchSales(collection: Collection): Promise<void> {
   const mostRecentSaleTime =
     (
       await collection.getLastSale(Marketplace.MagicEden)
@@ -122,7 +113,7 @@ async function fetchSales(
   try {
     const salesEvents = await MagicEden.getSales(
       collection,
-      mostRecentSaleTime,
+      mostRecentSaleTime
     );
 
     if (salesEvents.length === 0) {
@@ -163,6 +154,17 @@ async function fetchSales(
         await sleep(60);
       }
     }
+  }
+}
+
+async function run(): Promise<void> {
+  try {
+    while (true) {
+      await Promise.all([runCollections(), runSales()]);
+      await sleep(60 * 60);
+    }
+  } catch (e) {
+    console.error("Magic Eden adapter error:", e.message);
   }
 }
 

--- a/src/adapters/magic-eden-adapter.ts
+++ b/src/adapters/magic-eden-adapter.ts
@@ -45,7 +45,7 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const solInUSD = await Coingecko.getSolPrice();
+  const solInUSDPrices = await Coingecko.getHistoricalSolPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -57,7 +57,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for Magic Eden collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching Sales for Magic Eden collection:", collection.name);
-    await fetchSales(collection, solInUSD);
+    await fetchSales(collection, solInUSDPrices);
   }
 }
 
@@ -115,7 +115,7 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  solInUSD: number
+  solInUSDPrices: number[][]
 ): Promise<void> {
   const mostRecentSaleTime =
     (
@@ -125,7 +125,7 @@ async function fetchSales(
     const salesEvents = await MagicEden.getSales(
       collection,
       mostRecentSaleTime,
-      solInUSD
+      solInUSDPrices
     );
 
     if (salesEvents.length === 0) {

--- a/src/adapters/moralis-adapter.ts
+++ b/src/adapters/moralis-adapter.ts
@@ -69,12 +69,16 @@ async function fetchCollectionAddresses() {
 }
 
 async function run(): Promise<void> {
-  Moralis.initialize(MORALIS_APP_ID);
-  Moralis.serverURL = MORALIS_SERVER_URL;
+  try {
+    Moralis.initialize(MORALIS_APP_ID);
+    Moralis.serverURL = MORALIS_SERVER_URL;
 
-  while (true) {
-    await fetchCollectionAddresses();
-    await sleep(60 * 30);
+    while (true) {
+      await fetchCollectionAddresses();
+      await sleep(60 * 30);
+    }
+  } catch (e) {
+    console.error("Moralis adapter error:", e.message);
   }
 }
 

--- a/src/adapters/opensea-adapter.ts
+++ b/src/adapters/opensea-adapter.ts
@@ -57,7 +57,6 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const ethInUSDPrices = await Coingecko.getHistoricalEthPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -68,7 +67,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for OpenSea collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching sales for OpenSea collection:", collection.name);
-    await fetchSales(collection, ethInUSDPrices);
+    await fetchSales(collection);
   }
 }
 
@@ -102,7 +101,6 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  ethInUSDPrices: number[][]
 ): Promise<void> {
   let offset = 0;
   const limit = 100;
@@ -116,7 +114,6 @@ async function fetchSales(
         mostRecentSaleTime,
         offset,
         limit,
-        ethInUSDPrices
       );
       if (salesEvents.length === 0) {
         sleep(3);

--- a/src/adapters/opensea-adapter.ts
+++ b/src/adapters/opensea-adapter.ts
@@ -57,7 +57,7 @@ async function runCollections(): Promise<void> {
 
 async function runSales(): Promise<void> {
   const MAX_INT = 2_147_483_647;
-  const ethInUSD = await Coingecko.getEthPrice();
+  const ethInUSDPrices = await Coingecko.getHistoricalEthPrices();
   const collections = await Collection.getSorted(
     "totalVolume",
     "DESC",
@@ -68,7 +68,7 @@ async function runSales(): Promise<void> {
   console.log("Fetching sales for OpenSea collections:", collections.length);
   for (const collection of collections) {
     console.log("Fetching sales for OpenSea collection:", collection.name);
-    await fetchSales(collection, ethInUSD);
+    await fetchSales(collection, ethInUSDPrices);
   }
 }
 
@@ -102,7 +102,7 @@ async function fetchCollection(
 
 async function fetchSales(
   collection: Collection,
-  ethInUSD: number
+  ethInUSDPrices: number[][]
 ): Promise<void> {
   let offset = 0;
   const limit = 100;
@@ -116,7 +116,7 @@ async function fetchSales(
         mostRecentSaleTime,
         offset,
         limit,
-        ethInUSD
+        ethInUSDPrices
       );
       if (salesEvents.length === 0) {
         sleep(3);

--- a/src/adapters/opensea-adapter.ts
+++ b/src/adapters/opensea-adapter.ts
@@ -9,12 +9,6 @@ import { sleep } from "../utils";
 import { Coingecko } from "../api/coingecko";
 import { Blockchain, LowVolumeError, Marketplace } from "../types";
 
-async function run(): Promise<void> {
-  while (true) {
-    await Promise.all([runCollections(), runSales()]);
-  }
-}
-
 async function runCollections(): Promise<void> {
   const allCollections = await Collection.findNotFetchedSince(ONE_HOUR);
   const collections = allCollections.filter(
@@ -152,6 +146,16 @@ async function fetchSales(collection: Collection): Promise<void> {
       }
       continue;
     }
+  }
+}
+
+async function run(): Promise<void> {
+  try {
+    while (true) {
+      await Promise.all([runCollections(), runSales()]);
+    }
+  } catch (e) {
+    console.error("OpenSea adapter error:", e.message);
   }
 }
 

--- a/src/adapters/opensea-adapter.ts
+++ b/src/adapters/opensea-adapter.ts
@@ -4,7 +4,7 @@ import { DataAdapter } from ".";
 import { Collection } from "../models/collection";
 import { Sale } from "../models/sale";
 import { Statistic } from "../models/statistic";
-import { ONE_HOUR } from "../constants"
+import { ONE_HOUR } from "../constants";
 import { sleep } from "../utils";
 import { Coingecko } from "../api/coingecko";
 import { Blockchain, LowVolumeError, Marketplace } from "../types";
@@ -99,9 +99,7 @@ async function fetchCollection(
   collection.save();
 }
 
-async function fetchSales(
-  collection: Collection,
-): Promise<void> {
+async function fetchSales(collection: Collection): Promise<void> {
   let offset = 0;
   const limit = 100;
   const mostRecentSaleTime =
@@ -113,7 +111,7 @@ async function fetchSales(
         collection.address,
         mostRecentSaleTime,
         offset,
-        limit,
+        limit
       );
       if (salesEvents.length === 0) {
         sleep(3);

--- a/src/api/coingecko.ts
+++ b/src/api/coingecko.ts
@@ -1,10 +1,13 @@
 import axios from "axios";
 
 export class Coingecko {
-  private static ETH_ENDPOINT = "https://api.coingecko.com/api/v3/coins/ethereum";
-  private static ETH_HISTORICAL_ENDPOINT = "https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=max&interval=daily"
+  private static ETH_ENDPOINT =
+    "https://api.coingecko.com/api/v3/coins/ethereum";
+  private static ETH_HISTORICAL_ENDPOINT =
+    "https://api.coingecko.com/api/v3/coins/ethereum/market_chart?vs_currency=usd&days=max&interval=daily";
   private static SOL_ENDPOINT = "https://api.coingecko.com/api/v3/coins/solana";
-  private static SOL_HISTORICAL_ENDPOINT = "https://api.coingecko.com/api/v3/coins/solana/market_chart?vs_currency=usd&days=max&interval=daily"
+  private static SOL_HISTORICAL_ENDPOINT =
+    "https://api.coingecko.com/api/v3/coins/solana/market_chart?vs_currency=usd&days=max&interval=daily";
 
   public static async getEthPrice(): Promise<number> {
     const response = await axios.get(Coingecko.ETH_ENDPOINT);
@@ -13,7 +16,7 @@ export class Coingecko {
   }
 
   public static async getHistoricalEthPrices(): Promise<number[][]> {
-    const response = await axios.get(Coingecko.ETH_HISTORICAL_ENDPOINT)
+    const response = await axios.get(Coingecko.ETH_HISTORICAL_ENDPOINT);
     const { prices } = response.data;
     return prices;
   }
@@ -25,7 +28,19 @@ export class Coingecko {
   }
 
   public static async getHistoricalSolPrices(): Promise<number[][]> {
-    const response = await axios.get(Coingecko.SOL_HISTORICAL_ENDPOINT)
+    const response = await axios.get(Coingecko.SOL_HISTORICAL_ENDPOINT);
+    const { prices } = response.data;
+    return prices;
+  }
+
+  public static async getHistoricalPricesByAddress(
+    platform: string,
+    address: string,
+    base: string
+  ): Promise<number[][]> {
+    const response = await axios.get(
+      `https://api.coingecko.com/api/v3/coins/${platform}/contract/${address}/market_chart/?vs_currency=${base}&days=max`
+    );
     const { prices } = response.data;
     return prices;
   }

--- a/src/api/immutablex.ts
+++ b/src/api/immutablex.ts
@@ -1,6 +1,13 @@
 /* eslint-disable camelcase */
 import axios from "axios";
-import { getSlug, roundUSD, weiToETH, isSameDay } from "../utils";
+import {
+  getSlug,
+  roundUSD,
+  weiToETH,
+  isSameDay,
+  getPriceAtDate,
+  formatUSD,
+} from "../utils";
 import { ETHEREUM_DEFAULT_TOKEN_ADDRESS } from "../constants";
 import { CollectionData, StatisticData, SaleData } from "../types";
 import { Collection } from "../models/collection";
@@ -160,7 +167,7 @@ export class ImmutableX {
   public static async getSales(
     collection: Collection,
     occurredAfter: number,
-    ethInUSD: number
+    ethInUSDPrices: number[][]
   ): Promise<(SaleData | undefined)[]> {
     const filledOrders = await this.getAllOrders(
       collection.address,
@@ -186,7 +193,9 @@ export class ImmutableX {
       } = sale;
       const { id: txnHash } = sellData as ImmutableXERC721Data;
       const { quantity } = buyData as ImmutableXERC20Data;
-      const total_price = weiToETH(parseFloat(quantity));
+
+      const ethInUSD = getPriceAtDate(timestamp, ethInUSDPrices);
+      const price = weiToETH(parseFloat(quantity));
 
       return {
         collection: null,
@@ -194,8 +203,8 @@ export class ImmutableX {
         txnHash: txnHash.toLowerCase(),
         timestamp,
         paymentTokenAddress,
-        price: total_price,
-        priceUSD: BigInt(roundUSD(total_price * ethInUSD)),
+        price,
+        priceUSD: formatUSD(price * ethInUSD),
         buyerAddress: "",
         sellerAddress: seller_address || "",
       };

--- a/src/api/magic-eden.ts
+++ b/src/api/magic-eden.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import axios from "axios";
-import { roundUSD } from "../utils";
+import { formatUSD, getPriceAtDate, roundUSD } from "../utils";
 import { SOLANA_DEFAULT_TOKEN_ADDRESS } from "../constants";
 import { CollectionAndStatisticData, SaleData } from "../types";
 import { Collection } from "../models/collection";
@@ -110,7 +110,7 @@ export class MagicEden {
   public static async getSales(
     collection: Collection,
     occurredAfter: number,
-    solInUSD: number
+    solInUSDPrices: number[][]
   ): Promise<(SaleData | undefined)[]> {
     const url = `https://api-mainnet.magiceden.io/rpc/getGlobalActivitiesByQuery?q={"$match":{"collection_symbol":"${collection.slug}"}}`;
     const response = await axios.get(url);
@@ -136,14 +136,15 @@ export class MagicEden {
         seller_address,
       } = sale.parsedTransaction;
 
+      const solInUSD = getPriceAtDate(timestamp, solInUSDPrices) 
+      const price = total_price / MAGIC_EDEN_MULTIPLIER
+
       return {
         txnHash: txnHash.toLowerCase(),
         timestamp: timestamp,
         paymentTokenAddress,
-        price: total_price / MAGIC_EDEN_MULTIPLIER,
-        priceUSD: BigInt(
-          roundUSD((total_price / MAGIC_EDEN_MULTIPLIER) * solInUSD)
-        ),
+        price,
+        priceUSD: formatUSD(price * solInUSD),
         buyerAddress: buyer_address || "",
         sellerAddress: seller_address || "",
       };

--- a/src/api/magic-eden.ts
+++ b/src/api/magic-eden.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import axios from "axios";
-import { formatUSD, getPriceAtDate, roundUSD } from "../utils";
+import { formatUSD, roundUSD } from "../utils";
 import { SOLANA_DEFAULT_TOKEN_ADDRESS } from "../constants";
 import { CollectionAndStatisticData, SaleData } from "../types";
 import { Collection } from "../models/collection";
@@ -89,19 +89,19 @@ export class MagicEden {
       },
       statistics: {
         dailyVolume: one_day_volume / MAGIC_EDEN_MULTIPLIER,
-        dailyVolumeUSD: BigInt(
-          roundUSD((one_day_volume / MAGIC_EDEN_MULTIPLIER) * solInUSD)
+        dailyVolumeUSD: formatUSD(
+          (one_day_volume / MAGIC_EDEN_MULTIPLIER) * solInUSD
         ),
         owners: 0, // TODO add owners, data is not available from Magic Eden
         floor: floor_price / MAGIC_EDEN_MULTIPLIER || 0,
         floorUSD: roundUSD((floor_price / MAGIC_EDEN_MULTIPLIER) * solInUSD),
         totalVolume: total_volume / MAGIC_EDEN_MULTIPLIER,
-        totalVolumeUSD: BigInt(
-          roundUSD((total_volume / MAGIC_EDEN_MULTIPLIER) * solInUSD)
+        totalVolumeUSD: formatUSD(
+          (total_volume / MAGIC_EDEN_MULTIPLIER) * solInUSD
         ),
         marketCap: market_cap / MAGIC_EDEN_MULTIPLIER,
-        marketCapUSD: BigInt(
-          roundUSD((market_cap / MAGIC_EDEN_MULTIPLIER) * solInUSD)
+        marketCapUSD: formatUSD(
+          (market_cap / MAGIC_EDEN_MULTIPLIER) * solInUSD
         ),
       },
     };
@@ -109,8 +109,7 @@ export class MagicEden {
 
   public static async getSales(
     collection: Collection,
-    occurredAfter: number,
-    solInUSDPrices: number[][]
+    occurredAfter: number
   ): Promise<(SaleData | undefined)[]> {
     const url = `https://api-mainnet.magiceden.io/rpc/getGlobalActivitiesByQuery?q={"$match":{"collection_symbol":"${collection.slug}"}}`;
     const response = await axios.get(url);
@@ -136,15 +135,14 @@ export class MagicEden {
         seller_address,
       } = sale.parsedTransaction;
 
-      const solInUSD = getPriceAtDate(timestamp, solInUSDPrices) 
-      const price = total_price / MAGIC_EDEN_MULTIPLIER
+      const price = total_price / MAGIC_EDEN_MULTIPLIER;
 
       return {
         txnHash: txnHash.toLowerCase(),
         timestamp: timestamp,
         paymentTokenAddress,
         price,
-        priceUSD: formatUSD(price * solInUSD),
+        priceUSD: 0,
         buyerAddress: buyer_address || "",
         sellerAddress: seller_address || "",
       };

--- a/src/api/opensea.ts
+++ b/src/api/opensea.ts
@@ -4,7 +4,7 @@ import { URLSearchParams } from "url";
 
 import { ETHEREUM_DEFAULT_TOKEN_ADDRESS } from "../constants";
 import { OPENSEA_API_KEY, SECONDARY_OPENSEA_API_KEY } from "../../env";
-import { getPriceAtDate, roundUSD, weiToETH, formatUSD } from "../utils";
+import { roundUSD, convertByDecimals } from "../utils";
 import {
   CollectionAndStatisticData,
   CollectionData,
@@ -117,7 +117,6 @@ export class Opensea {
     occurredAfter: number,
     offset: number,
     limit: number,
-    ethInUSDPrices: number[][]
   ): Promise<(SaleData | undefined)[]> {
     const params: Record<string, string> = {
       asset_contract_address: address,
@@ -144,15 +143,15 @@ export class Opensea {
       const { transaction_hash: txnHash, timestamp } = sale.transaction;
       const { address: paymentTokenAddress, decimals } = paymentToken;
       const { total_price, winner_account, seller, created_date } = sale;
-      const ethInUSD = getPriceAtDate(timestamp, ethInUSDPrices);
-      const price = weiToETH(parseFloat(total_price));
+      const price = convertByDecimals(parseFloat(total_price), decimals);
 
       return {
         txnHash: txnHash.toLowerCase(),
         timestamp: timestamp || created_date,
         paymentTokenAddress,
         price,
-        priceUSD: formatUSD(price * ethInUSD),
+        priceBase: 0,
+        priceUSD: BigInt(0),
         buyerAddress: winner_account?.address || "",
         sellerAddress: seller?.address || "",
       };

--- a/src/models/historical-statistic.ts
+++ b/src/models/historical-statistic.ts
@@ -7,7 +7,6 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
-import { ETHEREUM_DEFAULT_TOKEN_ADDRESS } from "../constants";
 import { Collection } from "./collection";
 
 @Entity()
@@ -33,6 +32,9 @@ export class HistoricalStatistic extends BaseEntity {
 
   @Column({ type: "double precision" })
   dailyVolume: number;
+
+  @Column({ type: 'double precision'})
+  dailyVolumeBase: number;
 
   @Column({ type: "bigint" })
   dailyVolumeUSD: bigint;
@@ -81,7 +83,7 @@ export class HistoricalStatistic extends BaseEntity {
     slug: string
   ): Promise<any[]> {
     //TODO type
-    if (statistic !== "dailyVolume") {
+    if (statistic !== "dailyVolumeBase") {
       return [];
     }
     return this.createQueryBuilder("historical-statistic")
@@ -101,7 +103,7 @@ export class HistoricalStatistic extends BaseEntity {
     chain: string
   ): Promise<any[]> {
     //TODO type
-    if (statistic !== "dailyVolume") {
+    if (statistic !== "dailyVolumeBase") {
       return [];
     }
     return this.createQueryBuilder("historical-statistic")

--- a/src/models/sale.ts
+++ b/src/models/sale.ts
@@ -36,7 +36,7 @@ export class Sale extends BaseEntity {
   @Column({ type: "double precision" })
   price: number;
 
-  // The price denominated in the chain's native token 
+  // The price denominated in the chain's native token
   @Column({ type: "double precision", default: 0 })
   priceBase: number;
 
@@ -47,11 +47,23 @@ export class Sale extends BaseEntity {
   @Column()
   paymentTokenAddress: string;
 
-  static async getUnconverted(): Promise<Sale[]> {
+  static async getUnconvertedSales(): Promise<Sale[]> {
     return this.createQueryBuilder("sale")
       .where("sale.price != 0")
       .andWhere("sale.priceBase = 0")
       .andWhere("sale.priceUSD = 0")
       .getMany();
+  }
+
+  static async getUnconvertedSalesTokenAddresses(): Promise<
+    Record<string, string>[]
+  > {
+    return this.createQueryBuilder("sale")
+      .select("sale.paymentTokenAddress", "tokenAddress")
+      .distinct(true)
+      .where("sale.price != 0")
+      .andWhere("sale.priceBase = 0")
+      .andWhere("sale.priceUSD = 0")
+      .getRawMany();
   }
 }

--- a/src/models/sale.ts
+++ b/src/models/sale.ts
@@ -43,4 +43,11 @@ export class Sale extends BaseEntity {
 
   @Column()
   paymentTokenAddress: string;
+
+  static async getUnconverted(): Promise<Sale[]> {
+    return this.createQueryBuilder("sale")
+      .where("sale.priceBase = 0")
+      .orWhere("sale.priceUSD = 0")
+      .getMany();
+  }
 }

--- a/src/models/sale.ts
+++ b/src/models/sale.ts
@@ -32,12 +32,15 @@ export class Sale extends BaseEntity {
   @Column()
   marketplace: Marketplace;
 
+  // The price denominated in the paymentTokenAddress token
   @Column({ type: "double precision" })
   price: number;
 
+  // The price denominated in the chain's native token 
   @Column({ type: "double precision", default: 0 })
   priceBase: number;
 
+  // The price denominated in USD
   @Column({ type: "double precision", default: 0 })
   priceUSD: bigint;
 
@@ -46,8 +49,9 @@ export class Sale extends BaseEntity {
 
   static async getUnconverted(): Promise<Sale[]> {
     return this.createQueryBuilder("sale")
-      .where("sale.priceBase = 0")
-      .orWhere("sale.priceUSD = 0")
+      .where("sale.price != 0")
+      .andWhere("sale.priceBase = 0")
+      .andWhere("sale.priceUSD = 0")
       .getMany();
   }
 }

--- a/src/models/sale.ts
+++ b/src/models/sale.ts
@@ -55,9 +55,16 @@ export class Sale extends BaseEntity {
       .getMany();
   }
 
-  static async getUnconvertedSalesTokenAddresses(): Promise<
-    Record<string, string>[]
-  > {
+  static async getPaymentTokenAddresses(
+    all = true
+  ): Promise<Record<string, string>[]> {
+    if (all) {
+      return this.createQueryBuilder("sale")
+        .select("sale.paymentTokenAddress", "tokenAddress")
+        .distinct(true)
+        .getRawMany();
+    }
+
     return this.createQueryBuilder("sale")
       .select("sale.paymentTokenAddress", "tokenAddress")
       .distinct(true)

--- a/src/models/sale.ts
+++ b/src/models/sale.ts
@@ -36,6 +36,9 @@ export class Sale extends BaseEntity {
   price: number;
 
   @Column({ type: "double precision", default: 0 })
+  priceBase: number;
+
+  @Column({ type: "double precision", default: 0 })
   priceUSD: bigint;
 
   @Column()

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface SaleData {
   timestamp: string;
   paymentTokenAddress: string;
   price: number;
+  priceBase: number;
   priceUSD: bigint;
   sellerAddress: string;
   buyerAddress: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,8 +24,9 @@ export function getSlug(text: string): string {
     .replace(/[^\w-]+/g, "");
 }
 
-export function weiToETH(wei: number): number {
-  return wei / Math.pow(10, 18);
+// TODO Rename this to something more meaningful
+export function convertByDecimals(value: number, decimals: number): number {
+  return value / Math.pow(10, decimals);
 }
 
 export function getPriceAtDate(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,3 +44,7 @@ export function getPriceAtDate(
 
   return null;
 }
+
+export function formatUSD(price: number): bigint {
+  return BigInt(roundUSD(price));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,10 +33,11 @@ export function getPriceAtDate(
   date: string,
   historicalPrices: number[][] // [0] is a UNIX timestamp, [1] is the price
 ): number | null {
+  const givenDate = new Date(date);
+  
   const match = historicalPrices.find((priceArr) => {
-    const d1 = new Date(priceArr[0]);
-    const d2 = new Date(date);
-    return isSameDay(d1, d2);
+    const historicalDate = new Date(priceArr[0]);
+    return isSameDay(givenDate, historicalDate);
   });
 
   if (match) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,3 +27,20 @@ export function getSlug(text: string): string {
 export function weiToETH(wei: number): number {
   return wei / Math.pow(10, 18);
 }
+
+export function getPriceAtDate(
+  date: string,
+  historicalPrices: number[][] // [0] is a UNIX timestamp, [1] is the price
+): number | null {
+  const match = historicalPrices.find((priceArr) => {
+    const d1 = new Date(priceArr[0]);
+    const d2 = new Date(date);
+    return isSameDay(d1, d2);
+  });
+
+  if (match) {
+    return match[1];
+  }
+
+  return null;
+}


### PR DESCRIPTION
Doing several things here to improve the completeness and accuracy of the sales data:

- Calculating the USD value of a transaction based on the historical price at the time of sale rather than at the time of data collection.

- Including non-ETH and non-SOL (i.e. non native token) sales and calculating the base price (i.e. denominated in that chain's native token) and the USD price in order to add them to the overall stats and charts.

- Handling edge cases like transactions with a price of 0, payment tokens with no price data, etc.