### PR TITLE
Page PaintSwap NFT collections

### DIFF
--- a/src/api/paintswap.ts
+++ b/src/api/paintswap.ts
@@ -65,11 +65,20 @@ interface PaintSwapCollectionStats {
 
 export class PaintSwap {
   public static async getAllCollections(): Promise<PaintSwapCollectionData[]> {
-    const url = `https://api.paintswap.finance/v2/collections?sortByRecentVolume=true`;
-    const response = await axios.get(url);
-    const { collections } = response.data;
 
-    return collections;
+    const collections: PaintSwapCollectionData[] = []
+    const numToFetch = 1000
+    let numToSkip = 0
+    let end = false
+    while (!end) {
+      const res = await axios.get(`https://api.paintswap.finance/v2/collections?simplified=false&numToFetch=${numToFetch}&numToSkip=${numToSkip}&orderBy=id`)
+      collections.push(...res.data.collections)
+      end = res.data.end
+      numToSkip += numToFetch
+    }
+
+    // Filter by verified (non-community) collections
+    return collections.filter((item) => item.verified === true)
   }
 
   public static async getCollection(


### PR DESCRIPTION
We are approaching 1000 collections (currently at 950) which is an internal fetching limit. This PR adds some paging so it can continue to get all collections. Feel free to format as you wish.

Note: Have not set up a dev test environment for this