### PR TITLE
Regexp query

### DIFF
--- a/src/handlers/getSearch.ts
+++ b/src/handlers/getSearch.ts
@@ -24,11 +24,12 @@ const handler = async (event: APIGatewayProxyEvent): Promise<IResponse> => {
       `${OPENSEARCH_DOMAIN}/collections/_search`,
       {
         query: {
-          query_string: {
-            query,
-            default_field: "name",
-            fuzziness: "AUTO",
-          },
+          regexp: {
+            name: {
+              value: `^.*${query}.*$`,
+              case_insensitive: true,
+            }
+          }
         },
       },
       {


### PR DESCRIPTION
Change `query_string` for `regexp` query to match substring searches.

Before `aa` search was giving no result and `aaa` search was returning one result.
Ideally `aa` search should include `aaa` results.

Changed query following `elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html`